### PR TITLE
Feature/swift UI

### DIFF
--- a/FMPhotoPicker/FMPhotoPicker/source/SwiftUI/FMSwiftUIImagePicker.swift
+++ b/FMPhotoPicker/FMPhotoPicker/source/SwiftUI/FMSwiftUIImagePicker.swift
@@ -1,0 +1,72 @@
+//
+//  Created by Rob Jonson on 29/09/2022.
+//
+
+import Foundation
+import SwiftUI
+import HSHelpers
+
+@available(iOS 15.0, *)
+public struct FMSwiftUIImagePicker: UIViewControllerRepresentable {
+    
+    @Environment(\.presentationMode) var presentationMode
+    
+    var config: FMPhotoPickerConfig
+    @Binding var selectedImage: UIImage?
+    @Binding var selectedImages: [UIImage]
+    
+    public init(config: FMPhotoPickerConfig = FMPhotoPickerConfig(),
+                selectedImage: Binding<UIImage?>
+    ) {
+        self.config = config
+        self.config.selectMode = .single
+        self._selectedImage = selectedImage
+        self._selectedImages = .constant([])
+    }
+    
+    public init(config: FMPhotoPickerConfig = FMPhotoPickerConfig(),
+                selectedImages: Binding<[UIImage]>
+    ) {
+        self.config = config
+        self.config.selectMode = .multiple
+        self._selectedImage = .constant(nil)
+        self._selectedImages = selectedImages
+    }
+
+    public func makeUIViewController(context: UIViewControllerRepresentableContext<FMSwiftUIImagePicker>) -> FMPhotoPickerViewController {
+
+        let imagePicker = FMPhotoPickerViewController(config: config)
+        imagePicker.delegate = context.coordinator
+        
+        return imagePicker
+    }
+
+    public func updateUIViewController(_ uiViewController: FMPhotoPickerViewController, context: UIViewControllerRepresentableContext<FMSwiftUIImagePicker>) {
+
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final public class Coordinator: NSObject, FMPhotoPickerViewControllerDelegate {
+
+        var parent: FMSwiftUIImagePicker
+
+        init(_ parent: FMSwiftUIImagePicker) {
+            self.parent = parent
+        }
+
+        public func fmPhotoPickerController(_ picker: FMPhotoPickerViewController, didFinishPickingPhotoWith photos: [UIImage]) {
+            
+            if let image = photos.first {
+                parent.selectedImage = image
+            }
+            parent.selectedImages = photos
+
+            picker.dismiss(animated: true) {
+                self.parent.presentationMode.wrappedValue.dismiss()
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ struct ContentView: View {
 
         }
         .padding()
-        .sheet(isPresented: $showPicker) {
+		//Note - use fullScreenCover rather than sheet
+		//to avoid display issues on iPads
+        .fullScreenCover(isPresented: $showPicker) {
             FMSwiftUIImagePicker(config: FMPhotoPickerConfig(),
                                  selectedImage: self.$image)
         }

--- a/README.md
+++ b/README.md
@@ -172,6 +172,40 @@ A dictionary that allows you to customize language for your app.
 For details, see `FMPhotoPickerConfig.swift`   
 Type: `Dictionary`
 
+## SwiftUI
+
+You can pick an image or images using SwiftUI by presenting a sheet with `FMSwiftUIImagePicker`
+
+If you want to select multiple images, then simply pass a binding to an array of `UIImage`
+
+```swift
+struct ContentView: View {
+    @State var image:UIImage?
+    @State var showPicker:Bool = false
+
+    var body: some View {
+        VStack {
+            if let image {
+                Image(uiImage:image)
+                    .resizable()
+                    .frame(width:100,height:100)
+            }
+
+            Button("Pick a Photo") {
+                showPicker = true
+            }
+
+        }
+        .padding()
+        .sheet(isPresented: $showPicker) {
+            FMSwiftUIImagePicker(config: FMPhotoPickerConfig(),
+                                 selectedImage: self.$image)
+        }
+    }
+}
+```
+
+
 ## Customization
 ### Custom filter
 You can freely create your own filter by implementing the `FMFilterable` protocol.


### PR DESCRIPTION
This adds a simple wrapper for SwiftUI users

It's documented in the Readme - but essentially, it uses a standard fullscreenModal with a binding to an image or an array of images

```swift
struct ContentView: View {
    @State var image:UIImage?
    @State var showPicker:Bool = false

    var body: some View {
        VStack {
            if let image {
                Image(uiImage:image)
                    .resizable()
                    .frame(width:100,height:100)
            }

            Button("Pick a Photo") {
                showPicker = true
            }

        }
        .padding()
		//Note - use fullScreenCover rather than sheet
		//to avoid display issues on iPads
        .fullScreenCover(isPresented: $showPicker) {
            FMSwiftUIImagePicker(config: FMPhotoPickerConfig(),
                                 selectedImage: self.$image)
        }
    }
}
```

For multiple selection - just change the binding to `[UIImage]`